### PR TITLE
Add ability to change animation duration

### DIFF
--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationBar.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationBar.java
@@ -180,6 +180,12 @@ public class BottomNavigationBar extends FrameLayout {
         return this;
     }
 
+    public BottomNavigationBar setAnimationDuration(int animationDuration) {
+        this.mAnimationDuration = animationDuration;
+        this.mRippleAnimationDuration = (int) (animationDuration * 2.5);
+        return this;
+    }
+
     /**
      * will be public once all bugs are ressolved.
      */
@@ -337,6 +343,10 @@ public class BottomNavigationBar extends FrameLayout {
 
     public int getCurrentSelectedPosition() {
         return mSelectedPosition;
+    }
+
+    public int getAnimationDuration() {
+        return mAnimationDuration;
     }
 
     /**


### PR DESCRIPTION
Added setter and gettter for the animation duration to allow more flexbility to match other animations in apps.

Worth noting is that the ripple animation duration is not independently set, which is meant to keep the entire animation consistent. It's likely that it's more of a hassle to set them separately anyways. This commit sets mRippleAnimationDuration to be 2.5x mAnimationDuration to keep the 200:500 ratio that it's set at currently. As a result, we cast the double to an int which will round down in the case of a decimal, but on the off chance mAnimationDuration is set to an odd number we are still only losing a fraction of a millisecond - much smaller than is noticable.