### PR TITLE
Multiple code improvements - squid:S1118, squid:CommentedOutCodeLine, squid:S1185, squid:S1197, squid:MethodCyclomaticComplexity, squid:S1186, squid:S1068, squid:S1155

### DIFF
--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BadgeItem.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BadgeItem.java
@@ -122,16 +122,6 @@ public class BadgeItem {
     public BadgeItem setText(@Nullable CharSequence text) {
         this.mText = text;
         if (isWeakReferenceValid()) {
-//            if (TextUtils.isEmpty(text)) {
-//                if (!mIsHidden) {
-//                    hide();
-//                }
-//            } else {
-//                if (mIsHidden) {
-//                    show();
-//                }
-//                mTextViewRef.get().setText(text);
-//            }
             TextView textView = mTextViewRef.get();
             if (!TextUtils.isEmpty(text)) {
                 textView.setText(text);
@@ -430,7 +420,7 @@ public class BadgeItem {
                 animatorCompat.setListener(new ViewPropertyAnimatorListener() {
                     @Override
                     public void onAnimationStart(View view) {
-
+                        // Empty body
                     }
 
                     @Override

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationBar.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationBar.java
@@ -67,7 +67,6 @@ public class BottomNavigationBar extends FrameLayout {
     private boolean mScrollable = false;
 
     private static final int MIN_SIZE = 3;
-    private static final int MAX_SIZE = 5;
 
     ArrayList<BottomNavigationItem> mBottomNavigationItems = new ArrayList<>();
     ArrayList<BottomNavigationTab> mBottomNavigationTabs = new ArrayList<>();
@@ -132,11 +131,6 @@ public class BottomNavigationBar extends FrameLayout {
 
         ViewCompat.setElevation(this, getContext().getResources().getDimension(R.dimen.bottom_navigation_elevation));
         setClipToPadding(false);
-    }
-
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -264,33 +258,17 @@ public class BottomNavigationBar extends FrameLayout {
      * This method will take all changes in to consideration and redraws tabs.
      */
     public void initialise() {
-        if (mBottomNavigationItems.size() > 0) {
+        if (!mBottomNavigationItems.isEmpty()) {
             mTabContainer.removeAllViews();
-            if (mMode == MODE_DEFAULT) {
-                if (mBottomNavigationItems.size() <= MIN_SIZE) {
-                    mMode = MODE_FIXED;
-                } else {
-                    mMode = MODE_SHIFTING;
-                }
-            }
-            if (mBackgroundStyle == BACKGROUND_STYLE_DEFAULT) {
-                if (mMode == MODE_FIXED) {
-                    mBackgroundStyle = BACKGROUND_STYLE_STATIC;
-                } else {
-                    mBackgroundStyle = BACKGROUND_STYLE_RIPPLE;
-                }
-            }
-
-            if (mBackgroundStyle == BACKGROUND_STYLE_STATIC) {
-                mBackgroundOverlay.setBackgroundColor(mBackgroundColor);
-                mContainer.setBackgroundColor(mBackgroundColor);
-            }
+            modeDefault();
+            backgroundStyleDefault();
+            backgroundStyleStatic();
 
             int screenWidth = Utils.getScreenWidth(getContext());
 
             if (mMode == MODE_FIXED) {
 
-                int widths[] = BottomNavigationHelper.getMeasurementsForFixedMode(getContext(), screenWidth, mBottomNavigationItems.size(), mScrollable);
+                int[] widths = BottomNavigationHelper.getMeasurementsForFixedMode(getContext(), screenWidth, mBottomNavigationItems.size(), mScrollable);
                 int itemWidth = widths[0];
 
                 for (BottomNavigationItem currentItem : mBottomNavigationItems) {
@@ -300,7 +278,7 @@ public class BottomNavigationBar extends FrameLayout {
 
             } else if (mMode == MODE_SHIFTING) {
 
-                int widths[] = BottomNavigationHelper.getMeasurementsForShiftingMode(getContext(), screenWidth, mBottomNavigationItems.size(), mScrollable);
+                int[] widths = BottomNavigationHelper.getMeasurementsForShiftingMode(getContext(), screenWidth, mBottomNavigationItems.size(), mScrollable);
 
                 int itemWidth = widths[0];
                 int itemActiveWidth = widths[1];
@@ -313,8 +291,35 @@ public class BottomNavigationBar extends FrameLayout {
 
             if (mBottomNavigationTabs.size() > mFirstSelectedPosition) {
                 selectTabInternal(mFirstSelectedPosition, true, false);
-            } else if (mBottomNavigationTabs.size() > 0) {
+            } else if (!mBottomNavigationTabs.isEmpty()) {
                 selectTabInternal(0, true, false);
+            }
+        }
+    }
+
+    private void backgroundStyleStatic() {
+        if (mBackgroundStyle == BACKGROUND_STYLE_STATIC) {
+            mBackgroundOverlay.setBackgroundColor(mBackgroundColor);
+            mContainer.setBackgroundColor(mBackgroundColor);
+        }
+    }
+
+    private void backgroundStyleDefault() {
+        if (mBackgroundStyle == BACKGROUND_STYLE_DEFAULT) {
+            if (mMode == MODE_FIXED) {
+                mBackgroundStyle = BACKGROUND_STYLE_STATIC;
+            } else {
+                mBackgroundStyle = BACKGROUND_STYLE_RIPPLE;
+            }
+        }
+    }
+
+    private void modeDefault() {
+        if (mMode == MODE_DEFAULT) {
+            if (mBottomNavigationItems.size() <= MIN_SIZE) {
+                mMode = MODE_FIXED;
+            } else {
+                mMode = MODE_SHIFTING;
             }
         }
     }
@@ -442,12 +447,7 @@ public class BottomNavigationBar extends FrameLayout {
                     mBackgroundOverlay.post(new Runnable() {
                         @Override
                         public void run() {
-//                            try {
                             BottomNavigationHelper.setBackgroundWithRipple(clickedView, mContainer, mBackgroundOverlay, clickedView.getActiveColor(), mRippleAnimationDuration);
-//                            } catch (Exception e) {
-//                                mContainer.setBackgroundColor(clickedView.getActiveColor());
-//                                mBackgroundOverlay.setVisibility(View.GONE);
-//                            }
                         }
                     });
                 }
@@ -464,7 +464,6 @@ public class BottomNavigationBar extends FrameLayout {
      */
     private void sendListenerCall(int oldPosition, int newPosition) {
         if (mTabSelectedListener != null) {
-//                && oldPosition != -1) {
             if (oldPosition == newPosition) {
                 mTabSelectedListener.onTabReselected(newPosition);
             } else {

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationHelper.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationHelper.java
@@ -19,6 +19,8 @@ import android.widget.FrameLayout;
  */
 class BottomNavigationHelper {
 
+    private BottomNavigationHelper() {}
+
     /**
      * Used to get Measurements for MODE_FIXED
      *
@@ -30,7 +32,7 @@ class BottomNavigationHelper {
      */
     public static int[] getMeasurementsForFixedMode(Context context, int screenWidth, int noOfTabs, boolean scrollable) {
 
-        int result[] = new int[2];
+        int[] result = new int[2];
 
         int minWidth = (int) context.getResources().getDimension(R.dimen.fixed_min_width_small_views);
         int maxWidth = (int) context.getResources().getDimension(R.dimen.fixed_min_width);
@@ -59,7 +61,7 @@ class BottomNavigationHelper {
      */
     public static int[] getMeasurementsForShiftingMode(Context context, int screenWidth, int noOfTabs, boolean scrollable) {
 
-        int result[] = new int[2];
+        int[] result = new int[2];
 
         int minWidth = (int) context.getResources().getDimension(R.dimen.shifting_min_width_inactive);
         int maxWidth = (int) context.getResources().getDimension(R.dimen.shifting_max_width_inactive);
@@ -167,7 +169,6 @@ class BottomNavigationHelper {
         GradientDrawable shape = new GradientDrawable();
         shape.setShape(GradientDrawable.RECTANGLE);
         shape.setCornerRadius(context.getResources().getDimensionPixelSize(R.dimen.badge_corner_radius));
-//            shape.setCornerRadii(new float[]{8, 8, 8, 8, 0, 0, 0, 0});
         shape.setColor(badgeItem.getBackgroundColor(context));
         shape.setStroke(badgeItem.getBorderWidth(), badgeItem.getBorderColor(context));
         return shape;

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationTab.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/BottomNavigationTab.java
@@ -71,11 +71,6 @@ class BottomNavigationTab extends FrameLayout {
         setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT));
     }
 
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
     public void setActiveWidth(int activeWidth) {
         mActiveWidth = activeWidth;
     }

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/FixedBottomNavigationTab.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/FixedBottomNavigationTab.java
@@ -59,19 +59,12 @@ class FixedBottomNavigationTab extends BottomNavigationTab {
     public void select(boolean setActiveColor, int animationDuration) {
 
         labelView.animate().scaleX(labelScale).scaleY(labelScale).setDuration(animationDuration).start();
-//        labelView.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.fixed_label_active));
         super.select(setActiveColor, animationDuration);
     }
 
     @Override
     public void unSelect(boolean setActiveColor, int animationDuration) {
         labelView.animate().scaleX(1).scaleY(1).setDuration(animationDuration).start();
-//        labelView.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.fixed_label_inactive));
         super.unSelect(setActiveColor, animationDuration);
-    }
-
-    @Override
-    public void initialise(boolean setActiveColor) {
-        super.initialise(setActiveColor);
     }
 }

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/ShiftingBottomNavigationTab.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/ShiftingBottomNavigationTab.java
@@ -72,14 +72,8 @@ class ShiftingBottomNavigationTab extends BottomNavigationTab {
         anim.setDuration(animationDuration);
         this.startAnimation(anim);
 
-//        labelView.animate().scaleY(0).scaleX(0).setDuration(animationDuration).start();
         labelView.setScaleY(0);
         labelView.setScaleX(0);
-    }
-
-    @Override
-    public void initialise(boolean setActiveColor) {
-        super.initialise(setActiveColor);
     }
 
     public class ResizeWidthAnimation extends Animation {
@@ -97,11 +91,6 @@ class ShiftingBottomNavigationTab extends BottomNavigationTab {
         protected void applyTransformation(float interpolatedTime, Transformation t) {
             mView.getLayoutParams().width = mStartWidth + (int) ((mWidth - mStartWidth) * interpolatedTime);
             mView.requestLayout();
-        }
-
-        @Override
-        public void initialize(int width, int height, int parentWidth, int parentHeight) {
-            super.initialize(width, height, parentWidth, parentHeight);
         }
 
         @Override

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/behaviour/BottomVerticalScrollBehavior.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/behaviour/BottomVerticalScrollBehavior.java
@@ -20,7 +20,6 @@ public class BottomVerticalScrollBehavior<V extends View> extends VerticalScroll
     private static final Interpolator INTERPOLATOR = new LinearOutSlowInInterpolator();
     private int mBottomNavHeight;
     private int mDefaultOffset;
-//    private WeakReference<V> mViewRef;
 
     private ViewPropertyAnimatorCompat mTranslationAnimator;
     private boolean hidden = false;
@@ -30,7 +29,6 @@ public class BottomVerticalScrollBehavior<V extends View> extends VerticalScroll
         // First let the parent lay it out
         parent.onLayoutChild(child, layoutDirection);
 
-//        mViewRef = new WeakReference<>(child);
 
         child.post(new Runnable() {
             @Override
@@ -46,6 +44,7 @@ public class BottomVerticalScrollBehavior<V extends View> extends VerticalScroll
 
     @Override
     public void onNestedVerticalOverScroll(CoordinatorLayout coordinatorLayout, V child, @ScrollDirection int scrollDirection, int currentOverScroll, int totalOverScroll) {
+        // Empty body
     }
 
     @Override

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/behaviour/VerticalScrollingBehavior.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/behaviour/VerticalScrollingBehavior.java
@@ -95,16 +95,6 @@ public abstract class VerticalScrollingBehavior<V extends View> extends Coordina
     }
 
     @Override
-    public void onNestedScrollAccepted(CoordinatorLayout coordinatorLayout, V child, View directTargetChild, View target, int nestedScrollAxes) {
-        super.onNestedScrollAccepted(coordinatorLayout, child, directTargetChild, target, nestedScrollAxes);
-    }
-
-    @Override
-    public void onStopNestedScroll(CoordinatorLayout coordinatorLayout, V child, View target) {
-        super.onStopNestedScroll(coordinatorLayout, child, target);
-    }
-
-    @Override
     public void onNestedScroll(CoordinatorLayout coordinatorLayout, V child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
         super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
         if (dyUnconsumed > 0 && mTotalDyUnconsumed < 0) {
@@ -151,21 +141,5 @@ public abstract class VerticalScrollingBehavior<V extends View> extends Coordina
      * @return
      */
     protected abstract boolean onNestedDirectionFling(CoordinatorLayout coordinatorLayout, V child, View target, float velocityX, float velocityY, @ScrollDirection int scrollDirection);
-
-    @Override
-    public boolean onNestedPreFling(CoordinatorLayout coordinatorLayout, V child, View target, float velocityX, float velocityY) {
-        return super.onNestedPreFling(coordinatorLayout, child, target, velocityX, velocityY);
-    }
-
-    @Override
-    public WindowInsetsCompat onApplyWindowInsets(CoordinatorLayout coordinatorLayout, V child, WindowInsetsCompat insets) {
-
-        return super.onApplyWindowInsets(coordinatorLayout, child, insets);
-    }
-
-    @Override
-    public Parcelable onSaveInstanceState(CoordinatorLayout parent, V child) {
-        return super.onSaveInstanceState(parent, child);
-    }
 
 }

--- a/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/utils/Utils.java
+++ b/bottom-navigation-bar/src/main/java/com/ashokvarma/bottomnavigation/utils/Utils.java
@@ -15,6 +15,8 @@ import android.view.WindowManager;
  */
 public class Utils {
 
+    private Utils() {}
+
     /**
      * @param context used to get system services
      * @return screenWidth in pixels


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1185 - Overriding methods should do more than simply call the same method in the super class.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S1186 - Methods should not be empty.
squid:S1068 - Unused private fields should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1185
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S1186
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava