### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ or Ivy:
 ```
 
 
-##For Usage Docs [Visit Wiki][wikiLink]
-##For Usage Docs [Visit Wiki][wikiLink]
-##For Usage Docs [Visit Wiki][wikiLink]
+## For Usage Docs [Visit Wiki][wikiLink]
+## For Usage Docs [Visit Wiki][wikiLink]
+## For Usage Docs [Visit Wiki][wikiLink]
 
 
 ## License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
