### PR TITLE
Update the layout file accordingly

### DIFF
--- a/sample/src/main/res/layout/activity_home.xml
+++ b/sample/src/main/res/layout/activity_home.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#ececec"
     tools:context=".HomeActivity">
 
-    <android.support.v4.widget.NestedScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/nested_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -110,7 +110,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
 
     <com.ashokvarma.bottomnavigation.BottomNavigationBar
         android:id="@+id/bottom_navigation_bar"
@@ -119,7 +119,7 @@
         android:layout_gravity="bottom" />
     <!--app:bnbAutoHideEnabled="false"/>-->
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_home"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -128,4 +128,4 @@
         android:src="@drawable/ic_favorite_white_24dp"
         android:tint="@color/white" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fix the class cast Exception after androidx migration

`Process: com.ashokvarma.bottomnavigation.sample, PID: 22967
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ashokvarma.bottomnavigation.sample/com.ashokvarma.bottomnavigation.sample.HomeActivity}: android.view.InflateException: Binary XML file line #2 in com.ashokvarma.bottomnavigation.sample:layout/activity_home: Binary XML file line #2 in com.ashokvarma.bottomnavigation.sample:layout/activity_home: Error inflating class android.support.design.widget.CoordinatorLayout
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3388)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3527)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2123)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7710)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)`